### PR TITLE
Simplified ruby-end-insert-end

### DIFF
--- a/ruby-end.el
+++ b/ruby-end.el
@@ -98,9 +98,9 @@
 (defun ruby-end-insert-end ()
   "Closes block by inserting end."
   (save-excursion
-  (newline)
-  (insert "end")
-  (indent-according-to-mode)))
+    (newline)
+    (insert "end")
+    (indent-according-to-mode)))
 
 (defun ruby-end-expand-p ()
   "Checks if expansion (insertion of end) should be done."


### PR DESCRIPTION
ruby-end-insert-end seemed overly complex to me. indent-according-to-mode save you the need to do whitespace calculations. I've also removed the superflous empty line inserted, since most people would press return while on the first line and end up with two empty lines, instead of one.
