### PR TITLE
option for adding the blank line in between statement and end

### DIFF
--- a/ruby-end.el
+++ b/ruby-end.el
@@ -61,6 +61,11 @@
   :type 'boolean
   :group 'ruby)
 
+(defcustom ruby-end-insert-newline t
+  "*Disable or enable additional newline in between statement and end"
+  :type 'boolean
+  :group 'ruby)
+
 (defconst ruby-end-expand-postfix-modifiers-before-re
   "\\(?:if\\|unless\\|while\\)"
   "Regular expression matching statements before point.")
@@ -103,8 +108,10 @@
            (current-column))))
     (save-excursion
       (newline)
-      (indent-line-to (+ whites ruby-indent-level))
-      (newline)
+      (if ruby-end-insert-newline
+          (progn
+            (indent-line-to (+ whites ruby-indent-level))
+            (newline)))
       (indent-line-to whites)
       (insert "end"))))
 


### PR DESCRIPTION
Thanks for the great project :)

I'm probably an extreme corner case, but I use evil-mode (vim style editing in emacs) pretty much exclusively. Due to the way things are done in vim, the indented newline in between the statement and the end is actually more cumbersome then helpful. This makes that blank line optional (on by default)
