### PR TITLE
Call fallback commands interactively

### DIFF
--- a/ruby-end.el
+++ b/ruby-end.el
@@ -121,8 +121,8 @@
 (defun ruby-end-fallback (key)
   "Execute function that KEY was bound to before `ruby-end-mode'."
   (let ((ruby-end-mode nil))
-    (execute-kbd-macro
-     (edmacro-parse-keys key))))
+    (call-interactively
+     (key-binding (edmacro-parse-keys key) t))))
 
 (defun ruby-end-insert-end ()
   "Closes block by inserting end."


### PR DESCRIPTION
I had my "RET" bound to 'comment-indent-new-line, which doesn't work correctly unless it is called interactively. This commit calls the fallback command interactively to make sure any command that expects that works right.
