### PR TITLE
Add new option, ruby-end-expand-only-for-last-commands

### DIFF
--- a/features/ruby-end.feature
+++ b/features/ruby-end.feature
@@ -180,3 +180,24 @@ Feature: Insert end
       Proc.new do
 
       """
+
+  Scenario: Do not expand when the last command was not insertion
+    Given I restrict expansion to only after insertion
+    When I press "i"
+    And I press "f"
+    And I press "<left>"
+    And I press "<right>"
+    And I press "SPC"
+    Then I should see "if "
+    And end should not be insterted
+
+  Scenario: Expand when the last command was insertion
+    Given I restrict expansion to only after insertion
+    When I type "if" interactively
+    And I press "SPC"
+    Then I should see:
+    """
+    if 
+      
+    end
+    """

--- a/features/step-definitions/ruby-end-steps.el
+++ b/features/step-definitions/ruby-end-steps.el
@@ -45,3 +45,12 @@
 (Given "I disable expand on return"
        (lambda ()
          (setq ruby-end-expand-on-ret nil)))
+
+(Given "^I type \"\\([^\"]+\\)\" interactively"
+       (lambda (str)
+         (When "I type \"%s\"" str)
+         (setq this-command 'self-insert-command)))
+
+(Given "I restrict expansion to only after insertion"
+       (lambda ()
+         (setq ruby-end-expand-only-for-last-commands '(self-insert-command))))

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -10,7 +10,8 @@
 
 (Before
  (setq ruby-end-insert-newline t)
- (setq ruby-end-expand-on-ret t))
+ (setq ruby-end-expand-on-ret t)
+ (setq ruby-end-expand-only-for-last-commands nil))
 
 (require 'ruby-end)
 (require 'espuds)

--- a/ruby-end.el
+++ b/ruby-end.el
@@ -76,6 +76,13 @@
   :type 'boolean
   :group 'ruby)
 
+(defcustom ruby-end-expand-only-for-last-commands '(self-insert-command)
+  "List of `last-command' values to restrict expansion to, or nil.
+
+When nil, any `last-command' will do."
+  :type '(repeat function)
+  :group 'ruby)
+
 (defconst ruby-end-expand-postfix-modifiers-before-re
   "\\(?:if\\|unless\\|while\\)"
   "Regular expression matching statements before point.")
@@ -147,6 +154,8 @@
             ruby-end-expand-prefix-re)
           ruby-end-expand-postfix-modifiers-before-re)))
     (and
+     (or (not ruby-end-expand-only-for-last-commands)
+         (memq last-command ruby-end-expand-only-for-last-commands))
      (ruby-end-code-at-point-p)
      (or
       (looking-back ruby-end-expand-statement-modifiers-before-re)


### PR DESCRIPTION
IMO, this helps a lot with cutting on false positives.

Note, I couldn't manage to have "I type" or "I press" steps to set the right value of `last-command`, so this adds "I type ... interactively", as a hopefully temporary solution.
