### PR TITLE
Override ruby-end-insert-newline to t if RET is pressed

### DIFF
--- a/features/ruby-end.feature
+++ b/features/ruby-end.feature
@@ -96,6 +96,17 @@ Feature: Insert end
       end
       """
 
+  Scenario: Always insert newline after RET
+    Given insert newline is turned off
+    When I type "foo do"
+    And I press "RET"
+    Then I should see:
+      """
+      foo do
+        
+      end
+      """
+
   # NOTE:
   # I have to hax these two scenarios, since running Emacs in batch
   # mode does not set the text properties.

--- a/ruby-end.el
+++ b/ruby-end.el
@@ -119,7 +119,8 @@ When nil, any `last-command' will do."
   (interactive)
   (cond
    ((and ruby-end-expand-on-ret (ruby-end-expand-p))
-    (ruby-end-insert-end)
+    (let ((ruby-end-insert-newline t))
+      (ruby-end-insert-end))
     (forward-line 1)
     (indent-according-to-mode))
    (t


### PR DESCRIPTION
At the moment the combination of `ruby-end-expand-on-ret t` and `ruby-end-insert-newline nil` leads to uncomfortable situations when after expansion, cursor is just before the automatically inserted `end`. There's no quick way to go on to writing the class (or method) body, you have to do something like `C-j`, (EDIT:) `C-p`, `TAB`.

This commit fixes that.

Maybe we should update the `ruby-end-insert-newline` docstring, but I'm not sure how. Technically, that newline is not "additional" in this case.
